### PR TITLE
Add sfc method and remove uneeded dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,10 +16,8 @@ Roxygen: list(markdown = TRUE)
 Depends: R (>= 2.10)
 Imports: V8, 
          sf, 
-         magrittr,
-         jsonlite,
-         dplyr
-RoxygenNote: 7.1.0
+         jsonlite
+RoxygenNote: 7.1.2
 Suggests: testthat
 URL: https://joelgombin.github.io/concaveman/, http://www.github.com/joelgombin/concaveman/
 BugReports: http://www.github.com/joelgombin/concaveman/issues

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,5 +2,6 @@
 
 S3method(concaveman,matrix)
 S3method(concaveman,sf)
+S3method(concaveman,sfc)
 export(concaveman)
 importFrom(magrittr,"%>%")

--- a/R/concaveman.R
+++ b/R/concaveman.R
@@ -43,14 +43,32 @@ concaveman.matrix <- function(points, concavity = 2, length_threshold = 0) {
 #' @export
 #' @rdname concaveman
 concaveman.sf <- function(points, concavity = 2, length_threshold = 0) {
+  
+  crs <- sf::st_crs(points)
+  coords <- sf::st_coordinates(points)
+  res <- sf::st_cast(
+    sf::st_linestring(
+      concaveman(coords, concavity, length_threshold)
+      ), 
+    "POLYGON"
+    )
+  
+  sf::st_as_sf(sf::st_sfc(res), crs = crs)
+}
 
-  points %>%
-    dplyr::summarise(polygons =
-                concaveman(sf::st_coordinates(.), concavity, length_threshold) %>%
-                  as.matrix() %>%
-                  list %>%
-                  sf::st_polygon() %>%
-                  sf::st_sfc(crs = sf::st_crs(points))
-              )
+#' @export
+#' @rdname concaveman
+concaveman.sfc <- function(points, concavity = 2, length_threshold = 0) {
+  
+  crs <- sf::st_crs(points)
+  coords <- sf::st_coordinates(points)
+  res <- sf::st_cast(
+    sf::st_linestring(
+      concaveman(coords, concavity, length_threshold)
+    ), 
+    "POLYGON"
+  )
+  
+  sf::st_sfc(res, crs = crs)
 }
 

--- a/man/concaveman.Rd
+++ b/man/concaveman.Rd
@@ -5,6 +5,7 @@
 \alias{concaveman}
 \alias{concaveman.matrix}
 \alias{concaveman.sf}
+\alias{concaveman.sfc}
 \title{concaveman: A very fast 2D concave hull algorithm.}
 \usage{
 concaveman(points, concavity, length_threshold)
@@ -12,6 +13,8 @@ concaveman(points, concavity, length_threshold)
 \method{concaveman}{matrix}(points, concavity = 2, length_threshold = 0)
 
 \method{concaveman}{sf}(points, concavity = 2, length_threshold = 0)
+
+\method{concaveman}{sfc}(points, concavity = 2, length_threshold = 0)
 }
 \arguments{
 \item{points}{the points for which the concave hull must be computed. Can be represented as a matrix of coordinates or an \code{sf} object.}

--- a/tests/testthat/test_concaveman.R
+++ b/tests/testthat/test_concaveman.R
@@ -11,3 +11,12 @@ test_that("input and output formats works correctly", {
   expect_error(concaveman(array()))
 })
 
+test_that("outputs from methods are identical", {
+  cc_m <- unname(concaveman(sf::st_coordinates(points)))
+  cc_sf <- unname(sf::st_coordinates(concaveman(points))[,1:2])
+  cc_sfc <- unname(sf::st_coordinates(concaveman(sf::st_geometry(points)))[,1:2])
+  
+  expect_identical(cc_sf, cc_m)
+  expect_identical(cc_sfc, cc_m)
+  expect_identical(cc_sf, cc_sfc)
+})

--- a/tests/testthat/test_concaveman.R
+++ b/tests/testthat/test_concaveman.R
@@ -6,6 +6,7 @@ context("main tests")
 test_that("input and output formats works correctly", {
   expect_is(concaveman(sf::st_coordinates(points)), "matrix")
   expect_s3_class(concaveman(points), "sf")
+  expect_s3_class(concaveman(sf::st_geometry(points)), "sfc")
   # input from classes that don't inherit from matrix, sf or SpatialPoints should throw an error
   expect_error(concaveman(array()))
 })


### PR DESCRIPTION
Hi @joelgombin,

Just discoverd this great interface! I've gone ahead and made a pull request that implements a method for `sfc` objects in addition to sf objects.

This pull request:

- implements sfc method
- modifies sf method to no longer use magrittr and dplyr
- removes magrittr and dplyr as dependencies
- updates test to check input and ouput class for sfc objects
- adds additional test to check that outputs are identical for all methods